### PR TITLE
Report side as side not current_side

### DIFF
--- a/Automations/ZHA-Xiaomi_Cube_Controller.yaml
+++ b/Automations/ZHA-Xiaomi_Cube_Controller.yaml
@@ -732,7 +732,7 @@ action:
   event: zha_cube_last_action
   event_data:
     action: '{{ action }}'
-    side: '{{ current_side }}'
+    side: '{{ side }}'
     current_side: '{{ current_side }}'
     last_side: '{{ last_side }}'
     device_id: '{{ cube }}'


### PR DESCRIPTION
Reporting / event sensor output issue.
Does not affect operation of the BP, so no rev change.
issue #29 