### PR TITLE
Cube: Enable setting volume to 0 or 1 with large rotation angles

### DIFF
--- a/Scripts/volume_control_4_magic_cube.yaml
+++ b/Scripts/volume_control_4_magic_cube.yaml
@@ -106,7 +106,7 @@ sequence:
     data_template:
       volume_level: >-
         {% set v = state_attr(mp, 'volume_level') | float(0.4) %}
-        {{ v + 0.0000625 * delta }}
+        {{ min(max(0, v + 0.0000625 * delta), 1) }}
     target:
         entity_id: "{{ mp }}"
 


### PR DESCRIPTION
When the rotation angle is too large, the target volume was <0 or >1 and not set at all. By manually setting it to 0 or 1, the volume is set correctly.

Btw: Great scripts, thank you very much! When combining this one with the cube blueprint, I had to set the angle field type from number to template to use the relative_degrees from the trigger event.